### PR TITLE
chore: fix start script to use ts-node directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/index.ts",
   "scripts": {
-    "start": "node --loader ts-node/esm src/index.ts",
+    "start": "ts-node src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "gts lint",
     "clean": "gts clean",


### PR DESCRIPTION
The current start command fails with node 20 or node 18.9. This seems to be an issue related to the node --loader flag: https://github.com/TypeStrong/ts-node/issues/1997

Was able to get around it by calling ts-node directly on index.ts and run the validators