### PR TITLE
Adding validation rules for repurchase

### DIFF
--- a/src/test_data/Transactions.ocf.json
+++ b/src/test_data/Transactions.ocf.json
@@ -97,6 +97,41 @@
       "security_id": "stock_issuance_05",
       "comments": [],
       "reason_text": "Issued in error."
+    },
+    {
+      "id": "stock_repurchase_01",
+      "object_type": "TX_STOCK_REPURCHASE",
+      "date": "2023-01-15",
+      "security_id": "stock_issuance_01",
+      "quantity": "500000",
+      "price": { "amount": "0.0001", "currency": "USD" },
+      "balance_security_id": "stock_issuance_06",
+      "comments": [],
+      "consideration_text": "Repurchasing 200,000 shares and balance to OA-6"
+    },
+    {
+      "id": "si_06",
+      "object_type": "TX_STOCK_ISSUANCE",
+      "date": "2023-01-15",
+      "security_id": "stock_issuance_06",
+      "custom_id": "OA-6",
+      "stakeholder_id": "fionaFounder",
+      "security_law_exemptions": [],
+      "stock_class_id": "ordinaryA",
+      "share_price": { "amount": "0.0001", "currency": "USD" },
+      "quantity": "100000",
+      "stock_legend_ids": []
+    },
+    {
+      "id": "stock_repurchase_02",
+      "object_type": "TX_STOCK_REPURCHASE",
+      "date": "2023-01-15",
+      "security_id": "stock_issuance_06",
+      "quantity": "100000",
+      "price": { "amount": "0.0001", "currency": "USD" },
+      "balance_security_id": "",
+      "comments": [],
+      "consideration_text": "Repurchasing 100,000 shares for the full amount"
     }
   ]
 }

--- a/src/validators/stock/tx_stock_repurchase.ts
+++ b/src/validators/stock/tx_stock_repurchase.ts
@@ -44,7 +44,88 @@ const valid_tx_stock_repurchase = (context: any, event: any) => {
     );
   }
 
-  if (incoming_stockIssuance_validity && incoming_date_validity) {
+  let balance_stockIssuance_validity = true;
+  let balance_security_outgoing_date_validity = true;
+  if (event.data.balance_security_id) {
+    // Check that stock issuance for the balance security_id referenced by transaction exists in current state.
+    balance_stockIssuance_validity = false;
+    context.stockIssuances.forEach((ele: any) => {
+      if (
+        ele.security_id === event.data.balance_security_id &&
+        ele.object_type === 'TX_STOCK_ISSUANCE'
+      ) {
+        balance_stockIssuance_validity = true;
+        console.log(
+          `\x1b[92m\u2714 The balance security (${event.data.balance_security_id}) for this repurchase exists.\x1b[0m`
+        );
+      }
+    });
+    // Check to ensure that the date of transaction is the same day as the date of the balance stock issuance.
+    balance_security_outgoing_date_validity = false;
+    transactions.items.forEach((ele: any) => {
+      if (
+        ele.security_id === event.data.balance_security_id &&
+        ele.object_type === 'TX_STOCK_ISSUANCE'
+      ) {
+        if (ele.date === event.data.date) {
+          balance_security_outgoing_date_validity = true;
+          console.log(
+            `\x1b[92m\u2714 The date of this repurchase is the same as the date of the balance security (${event.data.balance_security_id}).\x1b[0m`
+          );
+        }
+      }
+    });
+  }
+  if (!balance_stockIssuance_validity) {
+    console.log(
+      `\x1b[91m\u2718 The balance security (${event.data.balance_security_id}) for this repurchase does not exist in the current cap table.\x1b[0m`
+    );
+  }
+  if (balance_stockIssuance_validity && !balance_security_outgoing_date_validity) {
+    console.log(
+      `\x1b[91m\u2718 The date of this repurchase is not the same as the date of the incoming security (${event.data.balance_security_id}).\x1b[0m`
+    );
+  }
+  
+  // Check that the sum of the quantities of the repurchase (and the balance issuance if it exists) equal to the quantity of the incoming security.
+  let repurchase_and_balance_sum_validity = false;
+  let repurchase_and_balance_quantity = parseFloat(event.data.quantity);
+  if (event.data.balance_security_id) {
+    context.stockIssuances.forEach((ele: any) => {
+      if (
+        ele.security_id === event.data.balance_security_id &&
+        ele.object_type === 'TX_STOCK_ISSUANCE'
+      ) {
+        repurchase_and_balance_quantity += parseFloat(ele.quantity);
+      }
+    });
+  }
+  context.stockIssuances.forEach((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type === 'TX_STOCK_ISSUANCE'
+    ) {
+      if (repurchase_and_balance_quantity === parseFloat(ele.quantity)) {
+        repurchase_and_balance_sum_validity = true;
+        console.log(
+          '\x1b[92m\u2714 The sum of the quantities of the repurchase (and balance issuance if applicable) is equal to the quantity of incoming issuance.\x1b[0m'
+        );
+      }
+    }
+  });
+
+  if (!repurchase_and_balance_sum_validity) {
+    console.log(
+      '\x1b[91m\u2718 The sum of the quantities of the repurchase (and balance issuance if applicable) is not equal to the quantity of incoming issuance.\x1b[0m'
+    );
+  }
+
+  if (
+    incoming_stockIssuance_validity && 
+    incoming_date_validity && 
+    balance_stockIssuance_validity && 
+    balance_security_outgoing_date_validity &&
+    repurchase_and_balance_sum_validity) {
     valid = true;
   }
 


### PR DESCRIPTION
Adding following rules:
1. If there is a balance_security_id, check it exists as a stock issuance
2. if there is a balance_security_id, check if the date of repurchase and date of resulting stock issuance matches
3. Verify repurchased quantity+balance_security_id's quantity(if applicable)=incoming security_id's quantity