### PR TITLE
Added more reissuance checks

### DIFF
--- a/src/test_data/test_company/Stakeholders.ocf.json
+++ b/src/test_data/test_company/Stakeholders.ocf.json
@@ -12,6 +12,12 @@
       "object_type": "STAKEHOLDER",
       "name": { "legal_name": "Charlie Chuck Cofounder" },
       "stakeholder_type": "INDIVIDUAL"
+    },
+    {
+      "id": "janeCTO",
+      "object_type": "STAKEHOLDER",
+      "name": { "legal_name": "Jane Eyre CTO" },
+      "stakeholder_type": "INDIVIDUAL"
     }
   ]
 }

--- a/src/test_data/test_company/StockClasses.ocf.json
+++ b/src/test_data/test_company/StockClasses.ocf.json
@@ -17,7 +17,7 @@
       "name": "Ordinary B",
       "class_type": "COMMON",
       "default_id_prefix": "OB",
-      "initial_shares_authorized": "0",
+      "initial_shares_authorized": "5000000",
       "votes_per_share": "1",
       "seniority": "1"
     },

--- a/src/test_data/test_company/Transactions.ocf.json
+++ b/src/test_data/test_company/Transactions.ocf.json
@@ -167,6 +167,53 @@
       "date": "2022-07-01",
       "security_id": "stock_issuance_10",
       "reason_text": "This stock should never have been issued!"
+    },
+    {
+      "id": "sib_1",
+      "object_type": "TX_STOCK_ISSUANCE",
+      "date": "2023-01-01",
+      "security_id": "stock_issuance_b_01",
+      "custom_id": "OB-1",
+      "stakeholder_id": "janeCTO",
+      "security_law_exemptions": [],
+      "stock_class_id": "ordinaryB",
+      "share_price": { "amount": "0.0001", "currency": "USD" },
+      "quantity": "25000",
+      "stock_legend_ids": []
+    },
+    {
+      "id": "sib_2",
+      "object_type": "TX_STOCK_ISSUANCE",
+      "date": "2023-02-01",
+      "security_id": "stock_issuance_b_02",
+      "custom_id": "OB-2",
+      "stakeholder_id": "janeCTO",
+      "security_law_exemptions": [],
+      "stock_class_id": "ordinaryB",
+      "share_price": { "amount": "0.0001", "currency": "USD" },
+      "quantity": "13500",
+      "stock_legend_ids": []
+    },
+    {
+      "id": "sib_3",
+      "object_type": "TX_STOCK_ISSUANCE",
+      "date": "2023-02-01",
+      "security_id": "stock_issuance_b_03",
+      "custom_id": "OB-3",
+      "stakeholder_id": "janeCTO",
+      "security_law_exemptions": [],
+      "stock_class_id": "ordinaryB",
+      "share_price": { "amount": "0.0001", "currency": "USD" },
+      "quantity": "11500",
+      "stock_legend_ids": []
+    },
+    {
+      "id": "sreissue_1",
+      "object_type": "TX_STOCK_REISSUANCE",
+      "date": "2023-02-01",
+      "security_id": "stock_issuance_b_01",
+      "resulting_security_ids": ["stock_issuance_b_02","stock_issuance_b_03"],
+      "reason_text": "This stock reissued in smaller amounts!"
     }
   ]
 }

--- a/src/validators/stock/tx_stock_reissuance.ts
+++ b/src/validators/stock/tx_stock_reissuance.ts
@@ -4,18 +4,21 @@ import {OcfMachineContext} from '../../ocfMachine';
 CURRENT CHECKS:
 A stock issuance with a corresponding security ID must exist for the security_id variable
 The date of the stock issuance referred to in the security_id must have a date equal to or earlier than the date of the stock reissuance
-
-MISSING CHECKS
 Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-The security_id of the stock issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a stock acceptance transaction.
 The dates of any stock issuances referred to in the resulting_security_ids variable must have a date equal to the date of the stock reissuance
+The security_id of the stock issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a stock acceptance transaction.
 The quantity of the stock issuance referred to in the security_id variable must equal the sum of the quantities of any stock issuances referred to in the resulting_security_ids variable
 The stock_class_id of the stock issuance referred to in the security_id variable must equal the stock_class_id of any stock issuances referred to in the resulting_security_ids variable
+The stakeholder_id of the stock issuance referred to in the security_id variable must equal the stakeholder_id of any stock issuances referred to in the resulting_security_ids variable
+
+MISSING CHECKS
+Split_transaction_id when provided exists under TX_STOCK_CLASS_SPLIT
+Split_transaction_id when provided must have the same date as the reissuance date
+Split_transaction_id when provided must have the same stock class as the incoming security's stock class
 */
 const valid_tx_stock_reissuance = (context: OcfMachineContext, event: any) => {
   let valid = false;
   const {transactions} = context.ocfPackageContent;
-  // TBC: validation of tx_stock_reissuance
 
   // Check that stock issuance in incoming security_id referenced by transaction exists in current state.
   let incoming_stockIssuance_validity = false;
@@ -37,12 +40,18 @@ const valid_tx_stock_reissuance = (context: OcfMachineContext, event: any) => {
   }
 
   // Check to ensure that the date of transaction is the same day or after the date of the incoming stock issuance.
+  let incoming_quantity=0;
+  let incoming_stock_class='';
+  let incoming_stakeholder='';
   let incoming_date_validity = false;
   transactions.forEach((ele: any) => {
     if (
       ele.security_id === event.data.security_id &&
       ele.object_type === 'TX_STOCK_ISSUANCE'
     ) {
+      incoming_quantity=ele.quantity;
+      incoming_stock_class=ele.stock_class_id;
+      incoming_stakeholder=ele.stakeholder_id
       if (ele.date <= event.data.date) {
         incoming_date_validity = true;
         console.log(
@@ -57,7 +66,149 @@ const valid_tx_stock_reissuance = (context: OcfMachineContext, event: any) => {
     );
   }
 
-  if (incoming_stockIssuance_validity && incoming_date_validity) {
+  // Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
+  let resulting_stockIssuances_validity = false;
+  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
+    const res = event.data.resulting_security_ids[i];
+    resulting_stockIssuances_validity = false;
+    transactions.map((ele: any) => {
+      if (ele.security_id === res && ele.object_type === 'TX_STOCK_ISSUANCE') {
+        resulting_stockIssuances_validity = true;
+        console.log(
+          `\x1b[92m\u2714 The resulting security (${res}) for this reissuance exists.\x1b[0m`
+        );
+      }
+    });
+    if (!resulting_stockIssuances_validity) {
+      console.log(
+        `\x1b[91m\u2718 The resulting security (${res}) for this reissuance does not exist in the current cap table.\x1b[0m`
+      );
+      break;
+    }
+  }
+
+  // Check the dates of the resulting stock issuances.
+  let resulting_dates_validity = false;
+  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
+    const res = event.data.resulting_security_ids[i];
+    resulting_dates_validity = false;
+    transactions.map((ele: any) => {
+      if (ele.security_id === res && ele.object_type === 'TX_STOCK_ISSUANCE') {
+        if (ele.date === event.data.date) {
+          resulting_dates_validity = true;
+          console.log(
+            `\x1b[92m\u2714 The date of this reissuance is the same as the date of the resulting security (${res}).\x1b[0m`
+          );
+        }
+      }
+    });
+    if (!resulting_dates_validity) {
+      console.log(
+        `\x1b[91m\u2718 The date of this reissuance is not the same as the date of the resulting security (${res}).\x1b[0m`
+      );
+      break;
+    }
+  }
+
+  //The security_id of the stock issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a stock acceptance transaction.
+  let only_transaction_validity = true;
+  transactions.map((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type !== 'TX_STOCK_ISSUANCE' &&
+      ele.object_type !== 'TX_STOCK_ACCEPTANCE' &&
+      !(ele.object_type === 'TX_STOCK_REISSUANCE' && ele.id === event.data.id)
+    ) {
+      only_transaction_validity = false;
+      console.log(
+        `\x1b[91m\u2718 The incoming security (${event.data.security_id}) for this resissuance is related to another transaction (${ele.object_type}) with id (${ele.id}).\x1b[0m`
+      );
+    }
+  });
+  if (only_transaction_validity) {
+    console.log(
+      `\x1b[92m\u2714 The incoming security (${event.data.security_id}) for this resissuance is not related to any other conflicting transaction.\x1b[0m`
+    );
+  }
+
+  // The quantity of the stock issuance referred to in the security_id variable must equal the sum of the quantities of any stock issuances referred to in the resulting_security_ids variable
+  let outgoing_resulting_sum = 0;
+  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
+    const res = event.data.resulting_security_ids[i];
+    context.stockIssuances.map((ele: any) => {
+      if (ele.security_id === res && ele.object_type === 'TX_STOCK_ISSUANCE') {
+        outgoing_resulting_sum += parseFloat(ele.quantity);
+      }
+    });
+  }
+
+  let outgoing_resulting_sum_validity = false;
+  if (outgoing_resulting_sum == incoming_quantity) {
+    outgoing_resulting_sum_validity = true;
+    console.log(
+      '\x1b[92m\u2714 The sum of the quantities of the resulting issuances is equal to the quantity of the reissued stock.\x1b[0m'
+    );
+  }
+
+  if (!outgoing_resulting_sum_validity) {
+    console.log(
+      '\x1b[91m\u2718 The sum of the quantities of the resulting issuances is not equal to the quantity of the reissued stock.\x1b[0m'
+    );
+  }
+
+  //The stock_class_id of the stock issuance referred to in the security_id variable must equal the stock_class_id of any stock issuances referred to in the resulting_security_ids variable
+  let resulting_stock_class_validity = false;
+  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
+    const res = event.data.resulting_security_ids[i];
+    resulting_stock_class_validity = false;
+    transactions.map((ele: any) => {
+      if (ele.security_id === res && ele.object_type === 'TX_STOCK_ISSUANCE') {
+        if (ele.stock_class_id == incoming_stock_class) {
+          resulting_stock_class_validity = true;
+          console.log(
+            `\x1b[92m\u2714 The stock class of this reissuance is the same as the stock class of the resulting security (${res}).\x1b[0m`
+          );
+        }
+      }
+    });
+    if (!resulting_stock_class_validity) {
+      console.log(
+        `\x1b[91m\u2718 The stock class of this reissuance is not the same as the stock class of the resulting security (${res}).\x1b[0m`
+      );
+      break;
+    }
+  }
+
+  let resulting_stakeholder_validity = false;
+  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
+    const res = event.data.resulting_security_ids[i];
+    resulting_stakeholder_validity = false;
+    transactions.map((ele: any) => {
+      if (ele.security_id === res && ele.object_type === 'TX_STOCK_ISSUANCE') {
+        if (ele.stakeholder_id == incoming_stakeholder) {
+          resulting_stakeholder_validity = true;
+          console.log(
+            `\x1b[92m\u2714 The stakeholder of this reissuance is the same as the stakeholder of the resulting security (${res}).\x1b[0m`
+          );
+        }
+      }
+    });
+    if (!resulting_stakeholder_validity) {
+      console.log(
+        `\x1b[91m\u2718 The stakeholder of this reissuance is not the same as the stakeholder of the resulting security (${res}).\x1b[0m`
+      );
+      break;
+    }
+  }
+
+  if (incoming_stockIssuance_validity && 
+    incoming_date_validity &&
+    resulting_stockIssuances_validity &&
+    resulting_dates_validity &&
+    only_transaction_validity &&
+    outgoing_resulting_sum_validity &&
+    resulting_stock_class_validity &&
+    resulting_stakeholder_validity) {
     valid = true;
   }
 


### PR DESCRIPTION
CURRENT CHECKS:

1. A stock issuance with a corresponding security ID must exist for the security_id variable
2. The date of the stock issuance referred to in the security_id must have a date equal to or earlier than the date of the stock reissuance
3. Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
4. The dates of any stock issuances referred to in the resulting_security_ids variable must have a date equal to the date of the stock reissuance
5. The security_id of the stock issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a stock acceptance transaction.
6. The quantity of the stock issuance referred to in the security_id variable must equal the sum of the quantities of any stock issuances referred to in the resulting_security_ids variable
7. The stock_class_id of the stock issuance referred to in the security_id variable must equal the stock_class_id of any stock issuances referred to in the resulting_security_ids variable
8. The stakeholder_id of the stock issuance referred to in the security_id variable must equal the stakeholder_id of any stock issuances referred to in the resulting_security_ids variable

MISSING CHECKS (to be added later after reviewing splits)

1. Split_transaction_id when provided exists under TX_STOCK_CLASS_SPLIT
2. Split_transaction_id when provided must have the same date as the reissuance date
3. Split_transaction_id when provided must have the same stock class as the incoming security's stock class